### PR TITLE
Update query in manage_khu.php to fetch data directly from KhuKTX table

### DIFF
--- a/public/admin/manage_khu.php
+++ b/public/admin/manage_khu.php
@@ -5,7 +5,7 @@ include_once __DIR__ . '/../../partials/heading.php';
 
 
 // Gọi function GetAllKhuKTX từ SQL
-$query = "SELECT * FROM GetAllKhuKTX()";
+$query = "SELECT * FROM KhuKTX";
 $stmt = $dbh->prepare($query);
 $stmt->execute();
 $areas = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Tóm tắt bởi Sourcery

Sửa lỗi:
- Sửa truy vấn trong manage_khu.php để lấy dữ liệu trực tiếp từ bảng KhuKTX thay vì sử dụng hàm GetAllKhuKTX.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix query in manage_khu.php to fetch data directly from KhuKTX table instead of using GetAllKhuKTX function.

</details>